### PR TITLE
Feature/template images and drawable fixes

### DIFF
--- a/iDroidLayout.podspec
+++ b/iDroidLayout.podspec
@@ -16,7 +16,7 @@ In Android layouts can be defined in XML. Views automatically adjust their size 
 
   s.author        = { "Tom Quist" => "tom@quist.de" }
 
-  s.platform      = :ios, "6.0"
+  s.platform      = :ios, "7.0"
   s.source        = { :git => "https://github.com/tomquist/iDroidLayout.git", :tag => "#{s.version}" }
   s.source_files  = 'iDroidLayout', 'iDroidLayout/**/*.{h,m}'
   s.framework     = 'QuartzCore', 'UIKit', 'CoreGraphics'

--- a/iDroidLayout/Resources/Drawable/IDLGradientDrawable.m
+++ b/iDroidLayout/Resources/Drawable/IDLGradientDrawable.m
@@ -200,7 +200,7 @@ CGPoint IDLGradientDestinationPointFromAngle(CGPoint origin, CGSize size, CGFloa
 
 - (CGGradientRef)currentGradient {
     if (_gradient == NULL) {
-        _gradient = CGGradientCreateWithColors(self.colorSpace, (CFArrayRef)self.cgColors, _colorPositions);
+        _gradient = CGGradientCreateWithColors(self.colorSpace, (__bridge CFArrayRef)self.cgColors, _colorPositions);
     }
     return _gradient;
 }
@@ -282,8 +282,8 @@ CGPoint IDLGradientDestinationPointFromAngle(CGPoint origin, CGSize size, CGFloa
     }
 }
 
-- (void)drawInContext:(CGContextRef)context {
-    CGRect rect = self.bounds;
+- (void)drawInContext:(CGContextRef)context withRect:(CGRect) parentRect {
+    CGRect rect = {parentRect.origin, self.bounds.size};
     IDLGradientDrawableConstantState *state = self.internalConstantState;
     NSArray* colors = state.colors;
     if (state.shape != IDLGradientDrawableShapeLine) {

--- a/iDroidLayout/Resources/IDLResourceManager.m
+++ b/iDroidLayout/Resources/IDLResourceManager.m
@@ -15,6 +15,7 @@
 #import "IDLXMLCache.h"
 #import "IDLColorStateList.h"
 #import "UIColor+IDL_ColorParser.h"
+#import "IDLBitmapDrawable.h"
 
 
 @interface IDLResourceManager ()
@@ -135,7 +136,7 @@ static IDLResourceManager *currentResourceManager;
 }
 
 - (UIImage *)imageForIdentifier:(NSString *)identifierString withCaching:(BOOL)withCaching {
-    UIImage *ret = nil;
+    id ret = nil;
     IDLResourceIdentifier *identifier = [self resourceIdentifierForString:identifierString];
     if (identifier.type == IDLResourceTypeColor) {
         UIColor *color = [self colorForIdentifier:identifierString];
@@ -151,6 +152,11 @@ static IDLResourceManager *currentResourceManager;
         if (withCaching && ret != nil) {
             identifier.cachedObject = ret;
         }
+
+        if ([ret isKindOfClass:[IDLBitmapDrawable class]]) {
+            ret = ((IDLBitmapDrawable *) ret).image;
+        }
+
     } else {
         NSLog(@"Could not create image from resource identifier %@: Invalid resource type", identifierString);
     }

--- a/iDroidLayout/Resources/StateList/IDLDrawableStateItem.m
+++ b/iDroidLayout/Resources/StateList/IDLDrawableStateItem.m
@@ -11,6 +11,7 @@
 #import "IDLResourceManager.h"
 #import "UIColor+IDL_ColorParser.h"
 #import "UIImage+IDL_FromColor.h"
+#import "IDLBitmapDrawable.h"
 
 @interface IDLDrawableStateItem ()
 
@@ -32,7 +33,12 @@
 - (UIImage *)image {
     UIImage *ret = nil;
     if ([[IDLResourceManager currentResourceManager] isValidIdentifier:self.resourceIdentifier]) {
-        ret = [[IDLResourceManager currentResourceManager] imageForIdentifier:self.resourceIdentifier];
+        IDLDrawable * drawable = [[IDLResourceManager currentResourceManager] drawableForIdentifier:self.resourceIdentifier];
+        if ([drawable isKindOfClass:[IDLBitmapDrawable class]]) {
+            ret = ((IDLBitmapDrawable *) drawable).image;
+        } else {
+            ret = [drawable renderToImage];
+        }
     } else {
         // Try to parse color string
         UIColor *color = [UIColor colorFromIDLColorString:self.resourceIdentifier];

--- a/iDroidLayout/Utils/UIImage+IDL_FromColor.h
+++ b/iDroidLayout/Utils/UIImage+IDL_FromColor.h
@@ -11,5 +11,6 @@
 @interface UIImage (IDL_FromColor)
 
 + (UIImage *)idl_imageFromColor:(UIColor *)color withSize:(CGSize)size;
++ (UIImage *)idl_image:(UIImage*) image withTintColor:(UIColor *)color;
 
 @end

--- a/iDroidLayout/Utils/UIImage+IDL_FromColor.m
+++ b/iDroidLayout/Utils/UIImage+IDL_FromColor.m
@@ -34,7 +34,23 @@
             image = image;
         }
     }
-    return image;;
+    return image;
+}
+
++ (UIImage *)idl_image:(UIImage*) image withTintColor:(UIColor *)color {
+    UIGraphicsBeginImageContextWithOptions(image.size, NO, image.scale);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextTranslateCTM(context, 0, image.size.height);
+    CGContextScaleCTM(context, 1.0, -1.0f);
+    CGContextSetBlendMode(context, kCGBlendModeNormal);
+    CGRect rect = CGRectMake(0, 0, image.size.width, image.size.height);
+    CGContextClipToMask(context, rect, image.CGImage);
+    CGContextSetFillColorWithColor(context, color.CGColor);
+    CGContextFillRect(context, rect);
+    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return newImage;
 }
 
 @end
+

--- a/iDroidLayout/View/IDLViewGroup.m
+++ b/iDroidLayout/View/IDLViewGroup.m
@@ -132,15 +132,4 @@
     [super layoutSubviews];
 }
 
-- (void) measureAndLayout {
-    IDLLayoutMeasureSpec widthMeasureSpec;
-    IDLLayoutMeasureSpec heightMeasureSpec;
-    widthMeasureSpec.size = self.frame.size.width;
-    heightMeasureSpec.size = self.frame.size.height;
-    widthMeasureSpec.mode = IDLLayoutMeasureSpecModeExactly;
-    heightMeasureSpec.mode = IDLLayoutMeasureSpecModeExactly;
-    [self measureWithWidthMeasureSpec:widthMeasureSpec heightMeasureSpec:heightMeasureSpec];
-    [self layoutWithFrame:self.frame];
-}
-
 @end

--- a/iDroidLayout/View/UIView+IDL_Layout.m
+++ b/iDroidLayout/View/UIView+IDL_Layout.m
@@ -382,6 +382,18 @@ static char visibilityKey;
     return CGSizeMake(size.width.size, size.height.size);
 }
 
+- (void) measureAndLayout {
+    IDLLayoutMeasureSpec widthMeasureSpec;
+    IDLLayoutMeasureSpec heightMeasureSpec;
+    widthMeasureSpec.size = self.frame.size.width;
+    heightMeasureSpec.size = self.frame.size.height;
+    widthMeasureSpec.mode = IDLLayoutMeasureSpecModeUnspecified;
+    heightMeasureSpec.mode = IDLLayoutMeasureSpecModeUnspecified;
+    [self measureWithWidthMeasureSpec:widthMeasureSpec heightMeasureSpec:heightMeasureSpec];
+    CGRect frame = {self.frame.origin, self.measuredSize};
+    [self layoutWithFrame:frame];
+}
+
 - (void)onMeasureWithWidthMeasureSpec:(IDLLayoutMeasureSpec)widthMeasureSpec heightMeasureSpec:(IDLLayoutMeasureSpec)heightMeasureSpec {
     CGSize minSize = [self suggestedMinimumSize];
     IDLLayoutMeasuredSize size;

--- a/iDroidLayout/Widgets/Categories/UIImageView+IDL_View.m
+++ b/iDroidLayout/Widgets/Categories/UIImageView+IDL_View.m
@@ -6,16 +6,18 @@
 //  Copyright (c) 2012 Tom Quist. All rights reserved.
 //
 
-#import "UIImageView+IDL_View.h"
 #import "UIView+IDL_Layout.h"
+#import "UIColor+IDL_ColorParser.h"
 #import "IDLResourceManager.h"
 
 @implementation UIImageView (Layout)
 
 - (void)setupFromAttributes:(NSDictionary *)attrs {
     [super setupFromAttributes:attrs];
+
+    IDLResourceManager * resMgr = [IDLResourceManager currentResourceManager];
     NSString *imageRes = attrs[@"src"];
-    IDLDrawableStateList *drawableStateList = [[IDLResourceManager currentResourceManager] drawableStateListForIdentifier:imageRes];
+    IDLDrawableStateList *drawableStateList = [resMgr drawableStateListForIdentifier:imageRes];
     if (drawableStateList != nil) {
         self.image = [drawableStateList imageForControlState:UIControlStateNormal];
         UIImage *highlightedImage = [drawableStateList imageForControlState:UIControlStateHighlighted];
@@ -51,6 +53,15 @@
             self.contentMode = UIViewContentModeBottomLeft;
         } else if ([scaleType isEqualToString:@"bottomRight"]) {
             self.contentMode = UIViewContentModeBottomRight;
+        }
+    }
+
+    NSString *colorRes = attrs[@"tintColor"];
+    if (colorRes) {
+        if ([resMgr isValidIdentifier:colorRes]) {
+            self.tintColor = [resMgr colorForIdentifier:colorRes];
+        } else {
+            self.tintColor = [UIColor colorFromIDLColorString:colorRes];
         }
     }
 }


### PR DESCRIPTION
These commit fix various problems with dynamic changes to drawables:

* layer drawable bounds changes no longer position child drawables incorrectly
* layer and bitmap drawable sizes are initialized correctly
* template and tinted images are supported using 'renderingMode' attribute
* UIImageView support for 'tintColor'
